### PR TITLE
Remove ".html" from all URLs

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,7 @@
+# Turn on rewrite engine
+RewriteEngine on
+
+# Remove HTML extensions from the URL
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_FILENAME}\.html -f
+RewriteRule ^(.*)$ $1.html [NC,L]

--- a/about.html
+++ b/about.html
@@ -4,86 +4,64 @@
 <!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
 <!--[if gt IE 8]><!-->
 <html lang="en-US" class="no-js">
-  <!--<![endif]-->
-  <head>
-    <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <title>About | Felicity Bank Inc.</title>
-    <link
-      rel="shortcut icon"
-      type="image/png"
-      href="assets/images/icon/dogecoin.png"
-    />
-    <link rel="stylesheet" href="assets/css/style.css" />
-    <meta name="description" content="" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1, shrink-to-fit=no"
-    />
-    <!-- Bootstrap CSS -->
-    <link
-      rel="stylesheet"
-      href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
-      integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T"
-      crossorigin="anonymous"
-    />
-  </head>
-  <body>
-    <!--[if lt IE 7]>
+<!--<![endif]-->
+
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <title>About | Felicity Bank Inc.</title>
+  <link rel="shortcut icon" type="image/png" href="assets/images/icon/dogecoin.png" />
+  <link rel="stylesheet" href="assets/css/style.css" />
+  <meta name="description" content="" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+  <!-- Bootstrap CSS -->
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
+    integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous" />
+</head>
+
+<body>
+  <!--[if lt IE 7]>
       <p class="browsehappy">
         You are using an <strong>outdated</strong> browser. Please
         <a href="#">upgrade your browser</a> to improve your experience.
       </p>
     <![endif]-->
-    <nav
-      class="navbar navbar-expand-sm navbar-light bg-light border"
-      style="height: 8vh;"
-    >
-      <div class="container">
-        <a href="#" class="navbar-brand">Felicity Bank Inc.</a>
-
-        <button
-          class="navbar-toggler"
-          data-toggle="collapse"
-          data-target="#navbarMenu"
-        >
-          <span class="navbar-toggler-icon"></span>
-        </button>
-
-        <div class="collapse navbar-collapse" id="navbarMenu">
-          <ul class="navbar-nav ml-auto">
-            <li class="nav-link">
-              <a href="index.html">Home</a>
-            </li>
-            <li class="nav-link">
-              <a href="invest.html">Investing</a>
-            </li>
-            <li class="nav-link">
-              <a
-                href="https://en.wikipedia.org/wiki/Technical_support_scam"
-                target="_blank"
-                >Report Fraud</a
-              >
-            </li>
-            <li class="nav-link">
-              <a href="contact.html">Contact</a>
-            </li>
-          </ul>
-        </div>
-      </div>
-    </nav>
-
-    <div style="height: 8vh;"></div>
-
-    <!-- in between the nav and login box -->
-
+  <nav class="navbar navbar-expand-sm navbar-light bg-light border" style="height: 8vh;">
     <div class="container">
-      <div class="page-header"></div>
+      <a href="#" class="navbar-brand">Felicity Bank Inc.</a>
 
-      <center>
-      <div
-        class="shadow-sm p-3 mb-5 boxcol rounded col-lg-8 col-md-8 col-sm-8 col-xs-12"
-      >
+      <button class="navbar-toggler" data-toggle="collapse" data-target="#navbarMenu">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+
+      <div class="collapse navbar-collapse" id="navbarMenu">
+        <ul class="navbar-nav ml-auto">
+          <li class="nav-link">
+            <a href="/">Home</a>
+          </li>
+          <li class="nav-link">
+            <a href="invest">Investing</a>
+          </li>
+          <li class="nav-link">
+            <a href="https://en.wikipedia.org/wiki/Technical_support_scam" target="_blank">Report Fraud</a>
+          </li>
+          <li class="nav-link">
+            <a href="contact">Contact</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+
+  <div style="height: 8vh;"></div>
+
+  <!-- in between the nav and login box -->
+
+  <div class="container">
+    <div class="page-header"></div>
+
+    <center>
+      <div class="shadow-sm p-3 mb-5 boxcol rounded col-lg-8 col-md-8 col-sm-8 col-xs-12">
         <h2>About Felicity Bank Inc</h2>
 
         <hr>
@@ -101,10 +79,11 @@
         <hr />
 
       </div>
-      </center>
-    </div>
+    </center>
+  </div>
   <footer>
     <p>Deposit products offered by Felicity Bank Inc, N.A. Member FDIC.</p>
     <p>Copyright &copy; 1969 - 2019 Felicity Bank Inc. All rights reserved. NMLSR ID 420024</p>
   </footer>
+
 </html>

--- a/account.html
+++ b/account.html
@@ -4,283 +4,259 @@
 <!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
 <!--[if gt IE 8]><!-->
 <html lang="en-US" class="no-js">
-  <!--<![endif]-->
-  <head>
-    <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <title>Account Details | Felicity Bank Inc.</title>
-    <link
-      rel="shortcut icon"
-      type="image/png"
-      href="assets/images/icon/dogecoin.png"
-    />
-    <meta name="description" content="" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1, shrink-to-fit=no"
-    />
-    <meta http-equiv="refresh" content="600;URL=inactivity.html">
-    <link rel="stylesheet" href="assets/css/account.css" />
-    <link
-      rel="stylesheet"
-      href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
-      integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T"
-      crossorigin="anonymous"
-    />
-  </head>
-  <body>
-    <!--[if lt IE 7]>
+<!--<![endif]-->
+
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <title>Account Details | Felicity Bank Inc.</title>
+  <link rel="shortcut icon" type="image/png" href="assets/images/icon/dogecoin.png" />
+  <meta name="description" content="" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+  <meta http-equiv="refresh" content="600;URL=inactivity">
+  <link rel="stylesheet" href="assets/css/account.css" />
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
+    integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous" />
+</head>
+
+<body>
+  <!--[if lt IE 7]>
       <p class="browsehappy">
         You are using an <strong>outdated</strong> browser. Please
         <a href="#">upgrade your browser</a> to improve your experience.
       </p>
     <![endif]-->
 
-    <nav
-      class="navbar navbar-expand-sm navbar-light bg-light border"
-      style="height: 8vh; width: 100%;"
-    >
-      <div class="container">
-        <a href="#" class="navbar-brand">Felicity Bank Inc.</a>
-
-        <button
-          class="navbar-toggler"
-          data-toggle="collapse"
-          data-target="#navbarMenu"
-        >
-          <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarMenu">
-          <ul class="navbar-nav ml-auto">
-            <li class="nav-link">
-              <a href="#">Business</a>
-            </li>
-            <li class="nav-link">
-              <a href="invest.html">Investing</a>
-            </li>
-            <li class="nav-link">
-              <a
-                href="https://en.wikipedia.org/wiki/Technical_support_scam"
-                target="_blank"
-                >Report Fraud</a
-              >
-            </li>
-            <li class="nav-link">
-              <a href="contact.html">Contact</a>
-            </li>
-            <li class="nav-link">
-              <a href="logout.html">Logout</a>
-            </li>
-          </ul>
-        </div>
-      </div>
-    </nav>
-
-    <!-- end of navbar -->
-
-    <div style="height: 3vh;"></div>
-
-    <!-- end of space, main content: -->
+  <nav class="navbar navbar-expand-sm navbar-light bg-light border" style="height: 8vh; width: 100%;">
     <div class="container">
-      <div class="page-header">
-        <div class="alert alert-info">
-          A new branch opened on 69<sup>th</sup> street next to the Piggly
-          Wiggly market. Contact your branch manager today.
-        </div>
-        <div class="alert alert-danger">
-          Due to a recent spike in fraud transfers, in order to transfer funds between your accounts please call our hotline 1-800-FRAUD-STOP
-        </div>
+      <a href="#" class="navbar-brand">Felicity Bank Inc.</a>
 
-        <!-- end of alerts/messages at the top -->
+      <button class="navbar-toggler" data-toggle="collapse" data-target="#navbarMenu">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarMenu">
+        <ul class="navbar-nav ml-auto">
+          <li class="nav-link">
+            <a href="#">Business</a>
+          </li>
+          <li class="nav-link">
+            <a href="invest">Investing</a>
+          </li>
+          <li class="nav-link">
+            <a href="https://en.wikipedia.org/wiki/Technical_support_scam" target="_blank">Report Fraud</a>
+          </li>
+          <li class="nav-link">
+            <a href="contact">Contact</a>
+          </li>
+          <li class="nav-link">
+            <a href="logout">Logout</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </nav>
 
-        <div class="row">
-          <div class="col-sm-8">
-            <h3>Accounts</h3>
-            <hr />
-            <!-- start of table -->
-            <table class="table table-striped border">
-              <thead>
-                <tr>
-                  <th>Account Type</th>
-                  <th>Account Number</th>
-                  <th>Current Balance</th>
-                  <th>Available Balance</th>
-                </tr>
-              </thead>
-              <tr>
-                <td>Personal Checking</td>
-                <td>****1337</td>
-                <td>$2,293.01</td>
-                <td>$2,293.01</td>
-              </tr>
-              <tr>
-                <td>Online Savings</td>
-                <td>****1930</td>
-                <td>$15,011.34</td>
-                <td>$15,011.34</td>
-              </tr>
-              <tr>
-                <td>Platinum AARP Credit Card</td>
-                <td>****4242</td>
-                <td>$420.69</td>
-                <td>$3,580.00</td>
-              </tr>
-            </table>
+  <!-- end of navbar -->
 
-            <div class="row">
-              <div class="col-sm-4">
-                <div class="card">
-                  <div class="card-body">
-                    <h5 class="card-title">What's Your Credit Score?</h5>
-                    <p class="card-text">
-                      Find out what your credit score is right now, seriously
-                      it's really easy.
-                    </p>
-                    <a href="#" class="card-link">Learn More</a>
-                  </div>
-                </div>
-              </div>
-              <div class="col-sm-4">
-                <div class="card">
-                  <div class="card-body">
-                    <h5 class="card-title">Join AARP Rewards</h5>
-                    <p class="card-text">
-                      You could be saving serious coin on everyday purchases.
-                    </p>
-                    <a href="#" class="card-link">Learn More</a>
-                  </div>
-                </div>
-              </div>
-              <div class="col-sm-4">
-                <div class="card">
-                  <div class="card-body">
-                    <h5 class="card-title">Record Low Interest Rates</h5>
-                    <p class="card-text">
-                      You're already approved. It takes just a moment to open an
-                      account.
-                    </p>
-                    <a href="#" class="card-link">Learn More</a>
-                  </div>
+  <div style="height: 3vh;"></div>
+
+  <!-- end of space, main content: -->
+  <div class="container">
+    <div class="page-header">
+      <div class="alert alert-info">
+        A new branch opened on 69<sup>th</sup> street next to the Piggly
+        Wiggly market. Contact your branch manager today.
+      </div>
+      <div class="alert alert-danger">
+        Due to a recent spike in fraud transfers, in order to transfer funds between your accounts please call our
+        hotline 1-800-FRAUD-STOP
+      </div>
+
+      <!-- end of alerts/messages at the top -->
+
+      <div class="row">
+        <div class="col-sm-8">
+          <h3>Accounts</h3>
+          <hr />
+          <!-- start of table -->
+          <table class="table table-striped border">
+            <thead>
+              <tr>
+                <th>Account Type</th>
+                <th>Account Number</th>
+                <th>Current Balance</th>
+                <th>Available Balance</th>
+              </tr>
+            </thead>
+            <tr>
+              <td>Personal Checking</td>
+              <td>****1337</td>
+              <td>$2,293.01</td>
+              <td>$2,293.01</td>
+            </tr>
+            <tr>
+              <td>Online Savings</td>
+              <td>****1930</td>
+              <td>$15,011.34</td>
+              <td>$15,011.34</td>
+            </tr>
+            <tr>
+              <td>Platinum AARP Credit Card</td>
+              <td>****4242</td>
+              <td>$420.69</td>
+              <td>$3,580.00</td>
+            </tr>
+          </table>
+
+          <div class="row">
+            <div class="col-sm-4">
+              <div class="card">
+                <div class="card-body">
+                  <h5 class="card-title">What's Your Credit Score?</h5>
+                  <p class="card-text">
+                    Find out what your credit score is right now, seriously
+                    it's really easy.
+                  </p>
+                  <a href="#" class="card-link">Learn More</a>
                 </div>
               </div>
             </div>
-            <div style="height: 2vh;"></div>
-            <a target="_blank" href="contact.html" class="btn btn-lg btn-warning">
-              Contact Support
-            </a>
+            <div class="col-sm-4">
+              <div class="card">
+                <div class="card-body">
+                  <h5 class="card-title">Join AARP Rewards</h5>
+                  <p class="card-text">
+                    You could be saving serious coin on everyday purchases.
+                  </p>
+                  <a href="#" class="card-link">Learn More</a>
+                </div>
+              </div>
+            </div>
+            <div class="col-sm-4">
+              <div class="card">
+                <div class="card-body">
+                  <h5 class="card-title">Record Low Interest Rates</h5>
+                  <p class="card-text">
+                    You're already approved. It takes just a moment to open an
+                    account.
+                  </p>
+                  <a href="#" class="card-link">Learn More</a>
+                </div>
+              </div>
+            </div>
           </div>
-          <div class="col-sm-4">
-            <h3>Pending Transactions</h3>
-            <hr />
-            <table class="table table-striped border">
-              <thead>
-                <tr>
-                  <th>Date</th>
-                  <th>Description</th>
-                  <th>Amount</th>
-                </tr>
-              </thead>
+          <div style="height: 2vh;"></div>
+          <a target="_blank" href="contact" class="btn btn-lg btn-warning">
+            Contact Support
+          </a>
+        </div>
+        <div class="col-sm-4">
+          <h3>Pending Transactions</h3>
+          <hr />
+          <table class="table table-striped border">
+            <thead>
               <tr>
-                <td><span class="today"></span></td>
-                <td>APL*ITUNES.COM/BILL</td>
-                <td>
-                  <span id="redhighlight">-$50.00</span>
-                </td>
+                <th>Date</th>
+                <th>Description</th>
+                <th>Amount</th>
               </tr>
-              <tr>
-                <td class="today"></td>
-                <td>Netflix</td>
-                <td>
-                  <span id="redhighlight">-$14.99</span>
-                </td>
-              </tr>
-              <tr>
-                <td class="today"></td>
-                <td>PokerStars Checkout</td>
-                <td>
-                  <span id="redhighlight">-$13.37</span>
-                </td>
-              </tr>
-              <tr>
-                <td class="today"></td>
-                <td>Cheque #103 Deposit</td>
-                <td>
-                  <span id="greenhighlight">$53.10</span>
-                </td>
-              </tr>
-              <tr>
-                <td class="today"></td>
-                <td>Social Security</td>
-                <td>
-                  <span id="greenhighlight">$1,392.19</span>
-                </td>
-              </tr>
-              <tr>
-                <td class="today"></td>
-                <td>PokerStars Checkout</td>
-                <td>
-                  <span id="redhighlight">-$13.37</span>
-                </td>
-              </tr>
-              <tr>
-                <td><span class="yesterday"></span></td>
-                <td>AMZN MARKETPLACE</td>
-                <td>
-                  <span id="redhighlight">-$100.00</span>
-                </td>
-              </tr>
-              <tr>
-                <td><span class="yesterday"></span></td>
-                <td>WINRAR/BILL</td>
-                <td>
-                  <span id="redhighlight">-$30.00</span>
-                </td>
-              </tr>
-              <tr>
-                <td><span class="twodays"></span></td>
-                <td>QVC*SHOPPING/BILL</td>
-                <td>
-                  <span id="redhighlight">-$140.50</span>
-                </td>
-              </tr>
-              <tr>
-                <td><span class="twodays"></span></td>
-                <td>Fashion Barn</td>
-                <td>
-                  <span id="redhighlight">-$333.50</span>
-                </td>
-              </tr>
-              <tr>
-                <td><span class="twodays"></span></td>
-                <td>McDonalds</td>
-                <td>
-                  <span id="redhighlight">-$18.20</span>
-                </td>
-              </tr>
-            </table>
-          </div>
+            </thead>
+            <tr>
+              <td><span class="today"></span></td>
+              <td>APL*ITUNES.COM/BILL</td>
+              <td>
+                <span id="redhighlight">-$50.00</span>
+              </td>
+            </tr>
+            <tr>
+              <td class="today"></td>
+              <td>Netflix</td>
+              <td>
+                <span id="redhighlight">-$14.99</span>
+              </td>
+            </tr>
+            <tr>
+              <td class="today"></td>
+              <td>PokerStars Checkout</td>
+              <td>
+                <span id="redhighlight">-$13.37</span>
+              </td>
+            </tr>
+            <tr>
+              <td class="today"></td>
+              <td>Cheque #103 Deposit</td>
+              <td>
+                <span id="greenhighlight">$53.10</span>
+              </td>
+            </tr>
+            <tr>
+              <td class="today"></td>
+              <td>Social Security</td>
+              <td>
+                <span id="greenhighlight">$1,392.19</span>
+              </td>
+            </tr>
+            <tr>
+              <td class="today"></td>
+              <td>PokerStars Checkout</td>
+              <td>
+                <span id="redhighlight">-$13.37</span>
+              </td>
+            </tr>
+            <tr>
+              <td><span class="yesterday"></span></td>
+              <td>AMZN MARKETPLACE</td>
+              <td>
+                <span id="redhighlight">-$100.00</span>
+              </td>
+            </tr>
+            <tr>
+              <td><span class="yesterday"></span></td>
+              <td>WINRAR/BILL</td>
+              <td>
+                <span id="redhighlight">-$30.00</span>
+              </td>
+            </tr>
+            <tr>
+              <td><span class="twodays"></span></td>
+              <td>QVC*SHOPPING/BILL</td>
+              <td>
+                <span id="redhighlight">-$140.50</span>
+              </td>
+            </tr>
+            <tr>
+              <td><span class="twodays"></span></td>
+              <td>Fashion Barn</td>
+              <td>
+                <span id="redhighlight">-$333.50</span>
+              </td>
+            </tr>
+            <tr>
+              <td><span class="twodays"></span></td>
+              <td>McDonalds</td>
+              <td>
+                <span id="redhighlight">-$18.20</span>
+              </td>
+            </tr>
+          </table>
         </div>
       </div>
     </div>
+  </div>
 
-    <div style="height: 8vh;"></div>
+  <div style="height: 8vh;"></div>
 
-    <!-- scripts and such; end of regular stuff -->
-    <script src="assets/js/account.js"></script>
-    <script
-      src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
-      integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
-      crossorigin="anonymous"
-    ></script>
-    <script
-      src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"
-      integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1"
-      crossorigin="anonymous"
-    ></script>
-    <script
-      src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
-      integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
-      crossorigin="anonymous"
-    ></script>
-  </body>
+  <!-- scripts and such; end of regular stuff -->
+  <script src="assets/js/account.js"></script>
+  <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
+    integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
+    crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"
+    integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1"
+    crossorigin="anonymous"></script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
+    integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
+    crossorigin="anonymous"></script>
+</body>
+
 </html>

--- a/apply.html
+++ b/apply.html
@@ -4,86 +4,64 @@
 <!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
 <!--[if gt IE 8]><!-->
 <html lang="en-US" class="no-js">
-  <!--<![endif]-->
-  <head>
-    <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <title>Apply | Felicity Bank Inc.</title>
-    <link
-      rel="shortcut icon"
-      type="image/png"
-      href="assets/images/icon/dogecoin.png"
-    />
-    <link rel="stylesheet" href="assets/css/style.css" />
-    <meta name="description" content="" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1, shrink-to-fit=no"
-    />
-    <!-- Bootstrap CSS -->
-    <link
-      rel="stylesheet"
-      href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
-      integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T"
-      crossorigin="anonymous"
-    />
-  </head>
-  <body>
-    <!--[if lt IE 7]>
+<!--<![endif]-->
+
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <title>Apply | Felicity Bank Inc.</title>
+  <link rel="shortcut icon" type="image/png" href="assets/images/icon/dogecoin.png" />
+  <link rel="stylesheet" href="assets/css/style.css" />
+  <meta name="description" content="" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+  <!-- Bootstrap CSS -->
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
+    integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous" />
+</head>
+
+<body>
+  <!--[if lt IE 7]>
       <p class="browsehappy">
         You are using an <strong>outdated</strong> browser. Please
         <a href="#">upgrade your browser</a> to improve your experience.
       </p>
     <![endif]-->
-    <nav
-      class="navbar navbar-expand-sm navbar-light bg-light border"
-      style="height: 8vh;"
-    >
-      <div class="container">
-        <a href="#" class="navbar-brand">Felicity Bank Inc.</a>
-
-        <button
-          class="navbar-toggler"
-          data-toggle="collapse"
-          data-target="#navbarMenu"
-        >
-          <span class="navbar-toggler-icon"></span>
-        </button>
-
-        <div class="collapse navbar-collapse" id="navbarMenu">
-          <ul class="navbar-nav ml-auto">
-            <li class="nav-link">
-              <a href="about.html">About Felicity Bank</a>
-            </li>
-            <li class="nav-link">
-              <a href="invest.html">Investing</a>
-            </li>
-            <li class="nav-link">
-              <a
-                href="https://en.wikipedia.org/wiki/Technical_support_scam"
-                target="_blank"
-                >Report Fraud</a
-              >
-            </li>
-            <li class="nav-link">
-              <a href="contact.html">Contact</a>
-            </li>
-          </ul>
-        </div>
-      </div>
-    </nav>
-
-    <div style="height: 8vh;"></div>
-
-    <!-- in between the nav and login box -->
-
+  <nav class="navbar navbar-expand-sm navbar-light bg-light border" style="height: 8vh;">
     <div class="container">
-      <div class="page-header"></div>
+      <a href="#" class="navbar-brand">Felicity Bank Inc.</a>
 
-      <center>
-      <div
-        class="shadow-sm p-3 mb-5 boxcol rounded col-lg-6 col-md-6 col-sm-6 col-xs-12"
-      >
+      <button class="navbar-toggler" data-toggle="collapse" data-target="#navbarMenu">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+
+      <div class="collapse navbar-collapse" id="navbarMenu">
+        <ul class="navbar-nav ml-auto">
+          <li class="nav-link">
+            <a href="about">About Felicity Bank</a>
+          </li>
+          <li class="nav-link">
+            <a href="invest">Investing</a>
+          </li>
+          <li class="nav-link">
+            <a href="https://en.wikipedia.org/wiki/Technical_support_scam" target="_blank">Report Fraud</a>
+          </li>
+          <li class="nav-link">
+            <a href="contact">Contact</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+
+  <div style="height: 8vh;"></div>
+
+  <!-- in between the nav and login box -->
+
+  <div class="container">
+    <div class="page-header"></div>
+
+    <center>
+      <div class="shadow-sm p-3 mb-5 boxcol rounded col-lg-6 col-md-6 col-sm-6 col-xs-12">
         <h2>Apply for Felicity Bank Inc</h2>
         <p style="font-size: 22px;">
           Thank you for choosing us!
@@ -97,84 +75,48 @@
         <form>
           <div class="form-group">
             <label>Full Name</label>
-            <input
-              type="name"
-              class="form-control"
-              id="exampleInputEmail1"
-              aria-describedby="nameHelp"
-              placeholder="Full Name"
-              style="width: 48%;"
-            />
+            <input type="name" class="form-control" id="exampleInputEmail1" aria-describedby="nameHelp"
+              placeholder="Full Name" style="width: 48%;" />
             <label>Email Address</label>
-            <input
-              type="Email"
-              class="form-control"
-              id="exampleInputEmail1"
-              aria-describedby="emailHelp"
-              placeholder="Email Address"
-              style="width: 48%;"
-            />
+            <input type="Email" class="form-control" id="exampleInputEmail1" aria-describedby="emailHelp"
+              placeholder="Email Address" style="width: 48%;" />
             <label>Username</label>
-            <input
-              type="username"
-              class="form-control"
-              id="exampleInputuser1"
-              aria-describedby="userHelp"
-              placeholder="Username"
-              style="width: 48%;"
-            />
+            <input type="username" class="form-control" id="exampleInputuser1" aria-describedby="userHelp"
+              placeholder="Username" style="width: 48%;" />
             <label>Password</label>
-            <input
-              type="password"
-              class="form-control"
-              id="exampleInputPassword1"
-              placeholder="Password"
-              style="width: 48%;"
-            />
+            <input type="password" class="form-control" id="exampleInputPassword1" placeholder="Password"
+              style="width: 48%;" />
             <label>Confirm Password</label>
-            <input
-              type="password"
-              class="form-control"
-              id="exampleInputPassword1"
-              placeholder="Confirm Password"
-              style="width: 48%;"
-            />
+            <input type="password" class="form-control" id="exampleInputPassword1" placeholder="Confirm Password"
+              style="width: 48%;" />
           </div>
 
-          <a href="processing.html" class="btn btn-primary">Complete</a>
+          <a href="processing" class="btn btn-primary">Complete</a>
         </form>
 
         <div style="height: 3vh;"></div>
 
-        <a href="index.html">Already have an account?</a>
+        <a href="index">Already have an account?</a>
         <div style="height: 1vh;"></div>
       </div>
-    </div>
+  </div>
 
-    <footer>
-      <p>Deposit products offered by Felicity Bank Inc, N.A. Member FDIC.</p>
-      <p>Copyright &copy; 1969 - 2019 Felicity Bank Inc. All rights reserved. NMLSR ID 420024</p>
-    </footer>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+  <footer>
+    <p>Deposit products offered by Felicity Bank Inc, N.A. Member FDIC.</p>
+    <p>Copyright &copy; 1969 - 2019 Felicity Bank Inc. All rights reserved. NMLSR ID 420024</p>
+  </footer>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 
-    <script
-      src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML"
-      async
-    ></script>
-    <script
-      src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
-      integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
-      crossorigin="anonymous"
-    ></script>
-    <script
-      src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"
-      integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1"
-      crossorigin="anonymous"
-    ></script>
-    <script
-      src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
-      integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
-      crossorigin="anonymous"
-    ></script>
-  </body>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML" async></script>
+  <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
+    integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
+    crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"
+    integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1"
+    crossorigin="anonymous"></script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
+    integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
+    crossorigin="anonymous"></script>
+</body>
+
 </html>

--- a/complete.html
+++ b/complete.html
@@ -4,93 +4,71 @@
 <!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
 <!--[if gt IE 8]><!-->
 <html lang="en-US" class="no-js">
-  <!--<![endif]-->
-  <head>
-    <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <title>Complete | Felicity Bank Inc.</title>
-    <link
-      rel="shortcut icon"
-      type="image/png"
-      href="assets/images/icon/dogecoin.png"
-    />
-    <link rel="stylesheet" href="assets/css/style.css" />
-    <link href="assets/font-awesome/css/font-awesome.min.css" rel="stylesheet" type="text/css">
-    <meta name="description" content="" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1, shrink-to-fit=no"
-    />
-    <!-- Bootstrap CSS -->
-    <link
-      rel="stylesheet"
-      href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
-      integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T"
-      crossorigin="anonymous"
-    />
-  </head>
-  <body>
-    <!--[if lt IE 7]>
+<!--<![endif]-->
+
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <title>Complete | Felicity Bank Inc.</title>
+  <link rel="shortcut icon" type="image/png" href="assets/images/icon/dogecoin.png" />
+  <link rel="stylesheet" href="assets/css/style.css" />
+  <link href="assets/font-awesome/css/font-awesome.min.css" rel="stylesheet" type="text/css">
+  <meta name="description" content="" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+  <!-- Bootstrap CSS -->
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
+    integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous" />
+</head>
+
+<body>
+  <!--[if lt IE 7]>
       <p class="browsehappy">
         You are using an <strong>outdated</strong> browser. Please
         <a href="#">upgrade your browser</a> to improve your experience.
       </p>
     <![endif]-->
-    <nav
-      class="navbar navbar-expand-sm navbar-light bg-light border"
-      style="height: 8vh;"
-    >
-      <div class="container">
-        <a href="#" class="navbar-brand">Felicity Bank Inc.</a>
-
-        <button
-          class="navbar-toggler"
-          data-toggle="collapse"
-          data-target="#navbarMenu"
-        >
-          <span class="navbar-toggler-icon"></span>
-        </button>
-
-        <div class="collapse navbar-collapse" id="navbarMenu">
-          <ul class="navbar-nav ml-auto">
-            <li class="nav-link">
-              <a href="index.html">Home</a>
-            </li>
-            <li class="nav-link">
-              <a href="about.html">About Felicity Bank</a>
-            </li>
-            <li class="nav-link">
-              <a href="invest.html">Investing</a>
-            </li>
-            <li class="nav-link">
-              <a
-                href="https://en.wikipedia.org/wiki/Technical_support_scam"
-                target="_blank"
-                >Report Fraud</a
-              >
-            </li>
-            <li class="nav-link">
-              <a href="contact.html">Contact</a>
-            </li>
-          </ul>
-        </div>
-      </div>
-    </nav>
-
-    <div style="height: 8vh;"></div>
-
-    <!-- in between the nav and login box -->
-
+  <nav class="navbar navbar-expand-sm navbar-light bg-light border" style="height: 8vh;">
     <div class="container">
-      <div class="page-header"></div>
+      <a href="#" class="navbar-brand">Felicity Bank Inc.</a>
 
-      <center>
-      <div
-        class="shadow-sm p-3 mb-5 boxcol rounded col-lg-8 col-md-8 col-sm-8 col-xs-12"
-      >
+      <button class="navbar-toggler" data-toggle="collapse" data-target="#navbarMenu">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+
+      <div class="collapse navbar-collapse" id="navbarMenu">
+        <ul class="navbar-nav ml-auto">
+          <li class="nav-link">
+            <a href="index">Home</a>
+          </li>
+          <li class="nav-link">
+            <a href="about">About Felicity Bank</a>
+          </li>
+          <li class="nav-link">
+            <a href="invest">Investing</a>
+          </li>
+          <li class="nav-link">
+            <a href="https://en.wikipedia.org/wiki/Technical_support_scam" target="_blank">Report Fraud</a>
+          </li>
+          <li class="nav-link">
+            <a href="contact">Contact</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+
+  <div style="height: 8vh;"></div>
+
+  <!-- in between the nav and login box -->
+
+  <div class="container">
+    <div class="page-header"></div>
+
+    <center>
+      <div class="shadow-sm p-3 mb-5 boxcol rounded col-lg-8 col-md-8 col-sm-8 col-xs-12">
         <span class="fa-stack fa-2x">
-            <font color="green"><i class="fa fa-circle fa-stack-2x"></i></font>
-            <i class="fa fa-check fa-stack-1x fa-inverse"></i>
+          <font color="green"><i class="fa fa-circle fa-stack-2x"></i></font>
+          <i class="fa fa-check fa-stack-1x fa-inverse"></i>
         </span>
         <h2>Application Complete</h2>
 
@@ -109,10 +87,11 @@
         <hr />
 
       </div>
-      </center>
-    </div>
+    </center>
+  </div>
   <footer>
     <p>Deposit products offered by Felicity Bank Inc, N.A. Member FDIC.</p>
     <p>Copyright &copy; 1969 - 2019 Felicity Bank Inc. All rights reserved. NMLSR ID 420024</p>
   </footer>
+
 </html>

--- a/connecting.html
+++ b/connecting.html
@@ -1,16 +1,20 @@
 ﻿<!doctype html>
- <html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <title>connecting...</title>
-        <meta http-equiv="refresh" content="15;URL=account.html">
-        <link rel="stylesheet" href="assets/css/connect.css">
-        <link href="https://fonts.googleapis.com/css?family=Lobster|Roboto:100&display=swap" rel="stylesheet">
-    </head>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <title>connecting...</title>
+    <meta http-equiv="refresh" content="15;URL=account">
+    <link rel="stylesheet" href="assets/css/connect.css">
+    <link href="https://fonts.googleapis.com/css?family=Lobster|Roboto:100&display=swap" rel="stylesheet">
+</head>
+
+<body>
+    <br />
+    <br />
+    <h1>Securely logging you in via our secure servers, please wait a moment...</h1>
+    <img src="assets/images/loading.gif" />
+
     <body>
-        <br/>
-        <br/>
-        <h1>Securely logging you in via our secure servers, please wait a moment...</h1>
-        <img src="assets/images/loading.gif"/>
-    <body>
+
 </html>

--- a/contact.html
+++ b/contact.html
@@ -4,150 +4,137 @@
 <!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
 <!--[if gt IE 8]><!-->
 <html lang="en-US" class="no-js">
-  <!--<![endif]-->
-  <head>
-    <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <title>Contact | Felicity Bank Inc.</title>
-    <link
-      rel="shortcut icon"
-      type="image/png"
-      href="assets/images/icon/dogecoin.png"
-    />
-    <link rel="stylesheet" href="assets/css/style.css" />
-    <meta name="description" content="" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1, shrink-to-fit=no"
-    />
-    <!-- Bootstrap CSS -->
-    <link
-      rel="stylesheet"
-      href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
-      integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T"
-      crossorigin="anonymous"
-    />
-  </head>
-  <body>
-    <!--[if lt IE 7]>
+<!--<![endif]-->
+
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <title>Contact | Felicity Bank Inc.</title>
+  <link rel="shortcut icon" type="image/png" href="assets/images/icon/dogecoin.png" />
+  <link rel="stylesheet" href="assets/css/style.css" />
+  <meta name="description" content="" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+  <!-- Bootstrap CSS -->
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
+    integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous" />
+</head>
+
+<body>
+  <!--[if lt IE 7]>
       <p class="browsehappy">
         You are using an <strong>outdated</strong> browser. Please
         <a href="#">upgrade your browser</a> to improve your experience.
       </p>
     <![endif]-->
-    <nav
-      class="navbar navbar-expand-sm navbar-light bg-light border"
-      style="height: 8vh;"
-    >
-      <div class="container">
-        <a href="#" class="navbar-brand">Felicity Bank Inc.</a>
-
-        <button
-          class="navbar-toggler"
-          data-toggle="collapse"
-          data-target="#navbarMenu"
-        >
-          <span class="navbar-toggler-icon"></span>
-        </button>
-
-        <div class="collapse navbar-collapse" id="navbarMenu">
-          <ul class="navbar-nav ml-auto">
-            <li class="nav-link">
-              <a href="index.html">Home</a>
-            </li>
-            <li class="nav-link">
-              <a href="about.html">About Felicity Bank</a>
-            </li>
-            <li class="nav-link">
-              <a href="invest.html">Investing</a>
-            </li>
-            <li class="nav-link">
-              <a
-                href="https://en.wikipedia.org/wiki/Technical_support_scam"
-                target="_blank"
-                >Report Fraud</a>
-            </li>
-          </ul>
-        </div>
-      </div>
-    </nav>
-
-    <div style="height: 8vh;"></div>
-
-    <!-- in between the nav and login box -->
-
+  <nav class="navbar navbar-expand-sm navbar-light bg-light border" style="height: 8vh;">
     <div class="container">
+      <a href="#" class="navbar-brand">Felicity Bank Inc.</a>
+
+      <button class="navbar-toggler" data-toggle="collapse" data-target="#navbarMenu">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+
+      <div class="collapse navbar-collapse" id="navbarMenu">
+        <ul class="navbar-nav ml-auto">
+          <li class="nav-link">
+            <a href="index">Home</a>
+          </li>
+          <li class="nav-link">
+            <a href="about">About Felicity Bank</a>
+          </li>
+          <li class="nav-link">
+            <a href="invest">Investing</a>
+          </li>
+          <li class="nav-link">
+            <a href="https://en.wikipedia.org/wiki/Technical_support_scam" target="_blank">Report Fraud</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+
+  <div style="height: 8vh;"></div>
+
+  <!-- in between the nav and login box -->
+
+  <div class="container">
     <div class="page-header"></div>
 
-        <!-- Contact Details Column -->
-        <div class="col-md-4 p-5 boxcol rounded float-right">
-            <h3>Contact Details</h3>
-            <p>
-                4200 West Fifth Street<br>Los Angeles, CA 90071<br>
-            </p>
-            <p><i class="fa fa-phone"></i>
-                <abbr title="Phone">Phone</abbr>: 1 (800) FELICITY</p>
-            <p><i class="fa fa-envelope-o"></i>
-                <abbr title="Email">E-mail</abbr>: <a href="mailto:Contact@FelicityBank.com">Contact@FelicityBank.com</a>
-            </p>
-            <p><i class="fa fa-clock-o"></i>
-                <abbr title="Hours">Hours</abbr>: Mon - Fri: 7:00 AM to 5:00 PM</p>
-            <ul class="list-unstyled list-inline list-social-icons">
-                <li>
-                    <a href="#"><i class="fa fa-facebook-square fa-2x"></i></a>
-                </li>
-                <li>
-                    <a href="#"><i class="fa fa-linkedin-square fa-2x"></i></a>
-                </li>
-                <li>
-                    <a href="#"><i class="fa fa-twitter-square fa-2x"></i></a>
-                </li>
-                <li>
-                    <a href="#"><i class="fa fa-google-plus-square fa-2x"></i></a>
-                </li>
-            </ul>
-        </div>
+    <!-- Contact Details Column -->
+    <div class="col-md-4 p-5 boxcol rounded float-right">
+      <h3>Contact Details</h3>
+      <p>
+        4200 West Fifth Street<br>Los Angeles, CA 90071<br>
+      </p>
+      <p><i class="fa fa-phone"></i>
+        <abbr title="Phone">Phone</abbr>: 1 (800) FELICITY</p>
+      <p><i class="fa fa-envelope-o"></i>
+        <abbr title="Email">E-mail</abbr>: <a href="mailto:Contact@FelicityBank.com">Contact@FelicityBank.com</a>
+      </p>
+      <p><i class="fa fa-clock-o"></i>
+        <abbr title="Hours">Hours</abbr>: Mon - Fri: 7:00 AM to 5:00 PM</p>
+      <ul class="list-unstyled list-inline list-social-icons">
+        <li>
+          <a href="#"><i class="fa fa-facebook-square fa-2x"></i></a>
+        </li>
+        <li>
+          <a href="#"><i class="fa fa-linkedin-square fa-2x"></i></a>
+        </li>
+        <li>
+          <a href="#"><i class="fa fa-twitter-square fa-2x"></i></a>
+        </li>
+        <li>
+          <a href="#"><i class="fa fa-google-plus-square fa-2x"></i></a>
+        </li>
+      </ul>
+    </div>
     <!-- /.row -->
 
     <!-- Contact Form -->
     <div class="row">
-        <div class="col-md-18">
-            <form name="sentMessage" id="contactForm" novalidate>
-                <div class="control-group form-group">
-                    <div class="controls">
-                        <label>Full Name:</label>
-                        <input type="text" class="form-control" id="name" required data-validation-required-message="Please enter your name.">
-                        <p class="help-block"></p>
-                    </div>
-                </div>
-                <div class="control-group form-group">
-                    <div class="controls">
-                        <label>Phone Number:</label>
-                        <input type="tel" class="form-control" id="phone" required data-validation-required-message="Please enter your phone number.">
-                    </div>
-                </div>
-                <div class="control-group form-group">
-                    <div class="controls">
-                        <label>Email Address:</label>
-                        <input type="email" class="form-control" id="email" required data-validation-required-message="Please enter your email address.">
-                    </div>
-                </div>
-                <div class="control-group form-group">
-                    <div class="controls">
-                        <label>Message:</label>
-                        <textarea rows="10" cols="100" class="form-control" id="message" required data-validation-required-message="Please enter your message" maxlength="999" style="resize:none"></textarea>
-                    </div>
-                </div>
-                <div id="success"></div>
-                <button type="submit" class="btn btn-success">Send Message</button>
-            </form>
-        </div>
+      <div class="col-md-18">
+        <form name="sentMessage" id="contactForm" novalidate>
+          <div class="control-group form-group">
+            <div class="controls">
+              <label>Full Name:</label>
+              <input type="text" class="form-control" id="name" required
+                data-validation-required-message="Please enter your name.">
+              <p class="help-block"></p>
+            </div>
+          </div>
+          <div class="control-group form-group">
+            <div class="controls">
+              <label>Phone Number:</label>
+              <input type="tel" class="form-control" id="phone" required
+                data-validation-required-message="Please enter your phone number.">
+            </div>
+          </div>
+          <div class="control-group form-group">
+            <div class="controls">
+              <label>Email Address:</label>
+              <input type="email" class="form-control" id="email" required
+                data-validation-required-message="Please enter your email address.">
+            </div>
+          </div>
+          <div class="control-group form-group">
+            <div class="controls">
+              <label>Message:</label>
+              <textarea rows="10" cols="100" class="form-control" id="message" required
+                data-validation-required-message="Please enter your message" maxlength="999"
+                style="resize:none"></textarea>
+            </div>
+          </div>
+          <div id="success"></div>
+          <button type="submit" class="btn btn-success">Send Message</button>
+        </form>
+      </div>
     </div>
     <!-- /.row -->
-    </div>
-    <br>
+  </div>
+  <br>
   <footer>
     <p>Deposit products offered by Felicity Bank Inc, N.A. Member FDIC.</p>
     <p>Copyright &copy; 1969 - 2019 Felicity Bank Inc. All rights reserved. NMLSR ID 420024</p>
   </footer>
+
 </html>

--- a/forgot.html
+++ b/forgot.html
@@ -4,89 +4,67 @@
 <!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
 <!--[if gt IE 8]><!-->
 <html lang="en-US" class="no-js">
-  <!--<![endif]-->
-  <head>
-    <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <title>Forgot | Felicity Bank Inc.</title>
-    <link
-      rel="shortcut icon"
-      type="image/png"
-      href="assets/images/icon/dogecoin.png"
-    />
-    <link rel="stylesheet" href="assets/css/style.css" />
-    <meta name="description" content="" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1, shrink-to-fit=no"
-    />
-    <!-- Bootstrap CSS -->
-    <link
-      rel="stylesheet"
-      href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
-      integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T"
-      crossorigin="anonymous"
-    />
-  </head>
-  <body>
-    <!--[if lt IE 7]>
+<!--<![endif]-->
+
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <title>Forgot | Felicity Bank Inc.</title>
+  <link rel="shortcut icon" type="image/png" href="assets/images/icon/dogecoin.png" />
+  <link rel="stylesheet" href="assets/css/style.css" />
+  <meta name="description" content="" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+  <!-- Bootstrap CSS -->
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
+    integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous" />
+</head>
+
+<body>
+  <!--[if lt IE 7]>
       <p class="browsehappy">
         You are using an <strong>outdated</strong> browser. Please
         <a href="#">upgrade your browser</a> to improve your experience.
       </p>
     <![endif]-->
-    <nav
-      class="navbar navbar-expand-sm navbar-light bg-light border"
-      style="height: 8vh;"
-    >
-      <div class="container">
-        <a href="#" class="navbar-brand">Felicity Bank Inc.</a>
-
-        <button
-          class="navbar-toggler"
-          data-toggle="collapse"
-          data-target="#navbarMenu"
-        >
-          <span class="navbar-toggler-icon"></span>
-        </button>
-
-        <div class="collapse navbar-collapse" id="navbarMenu">
-          <ul class="navbar-nav ml-auto">
-            <li class="nav-link">
-              <a href="index.html">Home</a>
-            </li>
-            <li class="nav-link">
-              <a href="about.html">About Felicity Bank</a>
-            </li>
-            <li class="nav-link">
-              <a href="invest.html">Investing</a>
-            </li>
-            <li class="nav-link">
-              <a
-                href="https://en.wikipedia.org/wiki/Technical_support_scam"
-                target="_blank"
-                >Report Fraud</a
-              >
-            </li>
-            <li class="nav-link">
-              <a href="contact.html">Contact</a>
-            </li>
-          </ul>
-        </div>
-      </div>
-    </nav>
-
-    <div style="height: 8vh;"></div>
-
-    <!-- in between the nav and login box -->
-
+  <nav class="navbar navbar-expand-sm navbar-light bg-light border" style="height: 8vh;">
     <div class="container">
-      <div class="page-header"></div>
+      <a href="#" class="navbar-brand">Felicity Bank Inc.</a>
 
-      <center>
-      <div
-        class="shadow-sm p-3 mb-5 boxcol rounded col-lg-6 col-md-6 col-sm-6 col-xs-12"
-      >
+      <button class="navbar-toggler" data-toggle="collapse" data-target="#navbarMenu">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+
+      <div class="collapse navbar-collapse" id="navbarMenu">
+        <ul class="navbar-nav ml-auto">
+          <li class="nav-link">
+            <a href="index">Home</a>
+          </li>
+          <li class="nav-link">
+            <a href="about">About Felicity Bank</a>
+          </li>
+          <li class="nav-link">
+            <a href="invest">Investing</a>
+          </li>
+          <li class="nav-link">
+            <a href="https://en.wikipedia.org/wiki/Technical_support_scam" target="_blank">Report Fraud</a>
+          </li>
+          <li class="nav-link">
+            <a href="contact">Contact</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+
+  <div style="height: 8vh;"></div>
+
+  <!-- in between the nav and login box -->
+
+  <div class="container">
+    <div class="page-header"></div>
+
+    <center>
+      <div class="shadow-sm p-3 mb-5 boxcol rounded col-lg-6 col-md-6 col-sm-6 col-xs-12">
         <h2>Account Reset for Felicity Bank Inc</h2>
         <p style="font-size: 22px;">
           Forgot your username or password?
@@ -98,49 +76,35 @@
 
         <form>
           <div class="form-group">
-            <input
-              type="Email"
-              class="form-control"
-              id="exampleInputEmail1"
-              aria-describedby="emailHelp"
-              placeholder="Email Address"
-              style="width: 48%;"
-            />
+            <input type="Email" class="form-control" id="exampleInputEmail1" aria-describedby="emailHelp"
+              placeholder="Email Address" style="width: 48%;" />
           </div>
 
-          <a href="sent.html" class="btn btn-primary">Reset</a>
+          <a href="sent" class="btn btn-primary">Reset</a>
         </form>
 
         <div style="height: 3vh;"></div>
 
         <div style="height: 1vh;"></div>
       </div>
-    </div>
+  </div>
 
-    <footer>
-      <p>Deposit products offered by Felicity Bank Inc, N.A. Member FDIC.</p>
-      <p>Copyright &copy; 1969 - 2019 Felicity Bank Inc. All rights reserved. NMLSR ID 420024</p>
-    </footer>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+  <footer>
+    <p>Deposit products offered by Felicity Bank Inc, N.A. Member FDIC.</p>
+    <p>Copyright &copy; 1969 - 2019 Felicity Bank Inc. All rights reserved. NMLSR ID 420024</p>
+  </footer>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 
-    <script
-      src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML"
-      async
-    ></script>
-    <script
-      src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
-      integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
-      crossorigin="anonymous"
-    ></script>
-    <script
-      src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"
-      integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1"
-      crossorigin="anonymous"
-    ></script>
-    <script
-      src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
-      integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
-      crossorigin="anonymous"
-    ></script>
-  </body>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML" async></script>
+  <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
+    integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
+    crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"
+    integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1"
+    crossorigin="anonymous"></script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
+    integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
+    crossorigin="anonymous"></script>
+</body>
+
 </html>

--- a/inactivity.html
+++ b/inactivity.html
@@ -1,11 +1,13 @@
 <!DOCTYPE html>
 <html>
-    <head>
-        <title>Signed out</title>
-    </head>
-    
-    <body>
-        <p>You have been signed out due to inactivity</p>
-        <a href="index.html">BACK TO HOME PAGE</a>
-    </body>
+
+<head>
+    <title>Signed out</title>
+</head>
+
+<body>
+    <p>You have been signed out due to inactivity</p>
+    <a href="/">BACK TO HOME PAGE</a>
+</body>
+
 </html>

--- a/index.html
+++ b/index.html
@@ -4,330 +4,263 @@
 <!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
 <!--[if gt IE 8]><!-->
 <html lang="en-US" class="no-js">
-  <!--<![endif]-->
-  <head>
-    <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <title>Welcome | Felicity Bank Inc.</title>
-    <link
-      rel="shortcut icon"
-      type="image/png"
-      href="assets/images/icon/dogecoin.png"
-    />
-    <link rel="stylesheet" href="assets/css/style.css" />
-    <meta name="description" content="" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1, shrink-to-fit=no"
-    />
-    <!-- Bootstrap CSS -->
-    <link
-      rel="stylesheet"
-      href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
-      integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T"
-      crossorigin="anonymous"
-    />
-  </head>
-  <body>
-    <!--[if lt IE 7]>
+<!--<![endif]-->
+
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <title>Welcome | Felicity Bank Inc.</title>
+  <link rel="shortcut icon" type="image/png" href="assets/images/icon/dogecoin.png" />
+  <link rel="stylesheet" href="assets/css/style.css" />
+  <meta name="description" content="" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+  <!-- Bootstrap CSS -->
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
+    integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous" />
+</head>
+
+<body>
+  <!--[if lt IE 7]>
       <p class="browsehappy">
         You are using an <strong>outdated</strong> browser. Please
         <a href="#">upgrade your browser</a> to improve your experience.
       </p>
     <![endif]-->
-    <nav
-      class="navbar navbar-expand-sm navbar-light bg-light border"
-      style="height: 8vh;"
-    >
-      <div class="container">
-        <a href="#" class="navbar-brand">Felicity Bank Inc.</a>
-
-        <button
-          class="navbar-toggler"
-          data-toggle="collapse"
-          data-target="#navbarMenu"
-        >
-          <span class="navbar-toggler-icon"></span>
-        </button>
-
-        <div class="collapse navbar-collapse" id="navbarMenu">
-          <ul class="navbar-nav ml-auto">
-            <li class="nav-link">
-              <a href="about.html">About Felicity Bank</a>
-            </li>
-            <li class="nav-link">
-              <a href="invest.html">Investing</a>
-            </li>
-            <li class="nav-link">
-              <a
-                href="https://en.wikipedia.org/wiki/Technical_support_scam"
-                target="_blank"
-                >Report Fraud</a
-              >
-            </li>
-            <li class="nav-link">
-              <a href="contact.html">Contact</a>
-            </li>
-          </ul>
-        </div>
-      </div>
-    </nav>
-
-    <div style="height: 8vh;"></div>
-
-    <!-- in between the nav and login box -->
-
+  <nav class="navbar navbar-expand-sm navbar-light bg-light border" style="height: 8vh;">
     <div class="container">
-      <div class="page-header"></div>
+      <a href="#" class="navbar-brand">Felicity Bank Inc.</a>
 
-      <div
-        class="shadow-sm p-3 mb-5 boxcol rounded col-lg-6 col-md-6 col-sm-6 col-xs-12 float-right"
-      >
-        <h2>Welcome to Felicity Bank Inc</h2>
-        <p style="font-size: 22px;">
-          Thank you for banking with us!
-        </p>
-        <p style="font-size: 18px;">
-          To get started with our award-winning online banking system please simply
-          login to your account below:
-        </p>
-        <hr />
+      <button class="navbar-toggler" data-toggle="collapse" data-target="#navbarMenu">
+        <span class="navbar-toggler-icon"></span>
+      </button>
 
-        <form>
-          <div class="form-group form-inline d-flex justify-content-between">
-            <input
-              type="email"
-              class="form-control"
-              id="exampleInputEmail1"
-              aria-describedby="emailHelp"
-              placeholder="Username"
-              style="width: 48%;"
-            />
-            <input
-              type="password"
-              class="form-control"
-              id="exampleInputPassword1"
-              placeholder="Password"
-              style="width: 48%;"
-            />
-          </div>
-          <button
-            type="button"
-            class="btn btn-success"
-            data-toggle="modal"
-            data-target="#captcha"
-          >
-            Login
-          </button>
-
-          <a href="apply.html" class="btn btn-primary">Apply Now</a>
-        </form>
-
-        <div style="height: 3vh;"></div>
-
-        <a href="forgot.html">Forgot your username or password?</a>
-        <div style="height: 1vh;"></div>
-        <p style="font-size: 12px;">
-          Microsoft will never ask you for your banking details...
-        </p>
+      <div class="collapse navbar-collapse" id="navbarMenu">
+        <ul class="navbar-nav ml-auto">
+          <li class="nav-link">
+            <a href="about">About Felicity Bank</a>
+          </li>
+          <li class="nav-link">
+            <a href="invest">Investing</a>
+          </li>
+          <li class="nav-link">
+            <a href="https://en.wikipedia.org/wiki/Technical_support_scam" target="_blank">Report Fraud</a>
+          </li>
+          <li class="nav-link">
+            <a href="contact">Contact</a>
+          </li>
+        </ul>
       </div>
     </div>
+  </nav>
 
-    <img class="app" src="assets/images/download-app.png">
+  <div style="height: 8vh;"></div>
 
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-    <script>
-      $(document).ready(function() {
-        $('a[href="#gen-new"]').click(function() {
-          $("#generate-problem").css("display", "none");
-          $("#math-problem").css("display", "none");
-          $("#loading").css("display", "inline");
-          window.setTimeout(function() {
-            $("#loading").css("display", "none");
-            $("#new-problem").css("display", "inline");
-          }, 1200);
-          $("#new-problem").fadeIn(3000);
-        });
-      });
-    </script>
+  <!-- in between the nav and login box -->
 
-    <script
-      src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML"
-      async
-    ></script>
-    <script
-      src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
-      integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
-      crossorigin="anonymous"
-    ></script>
-    <script
-      src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"
-      integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1"
-      crossorigin="anonymous"
-    ></script>
-    <script
-      src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
-      integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
-      crossorigin="anonymous"
-    ></script>
-  </body>
-  <div class="modal fade" id="captcha">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h3>For your safety...</h3>
+  <div class="container">
+    <div class="page-header"></div>
+
+    <div class="shadow-sm p-3 mb-5 boxcol rounded col-lg-6 col-md-6 col-sm-6 col-xs-12 float-right">
+      <h2>Welcome to Felicity Bank Inc</h2>
+      <p style="font-size: 22px;">
+        Thank you for banking with us!
+      </p>
+      <p style="font-size: 18px;">
+        To get started with our award-winning online banking system please simply
+        login to your account below:
+      </p>
+      <hr />
+
+      <form>
+        <div class="form-group form-inline d-flex justify-content-between">
+          <input type="email" class="form-control" id="exampleInputEmail1" aria-describedby="emailHelp"
+            placeholder="Username" style="width: 48%;" />
+          <input type="password" class="form-control" id="exampleInputPassword1" placeholder="Password"
+            style="width: 48%;" />
         </div>
-        <div class="modal-body">
+        <button type="button" class="btn btn-success" data-toggle="modal" data-target="#captcha">
+          Login
+        </button>
+
+        <a href="apply" class="btn btn-primary">Apply Now</a>
+      </form>
+
+      <div style="height: 3vh;"></div>
+
+      <a href="forgot">Forgot your username or password?</a>
+      <div style="height: 1vh;"></div>
+      <p style="font-size: 12px;">
+        Microsoft will never ask you for your banking details...
+      </p>
+    </div>
+  </div>
+
+  <img class="app" src="assets/images/download-app.png">
+
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+  <script>
+    $(document).ready(function () {
+      $('a[href="#gen-new"]').click(function () {
+        $("#generate-problem").css("display", "none");
+        $("#math-problem").css("display", "none");
+        $("#loading").css("display", "inline");
+        window.setTimeout(function () {
+          $("#loading").css("display", "none");
+          $("#new-problem").css("display", "inline");
+        }, 1200);
+        $("#new-problem").fadeIn(3000);
+      });
+    });
+  </script>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML" async></script>
+  <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
+    integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
+    crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"
+    integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1"
+    crossorigin="anonymous"></script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
+    integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
+    crossorigin="anonymous"></script>
+</body>
+<div class="modal fade" id="captcha">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h3>For your safety...</h3>
+      </div>
+      <div class="modal-body">
+        <p>
+          <strong>Please solve the following simple math problem:</strong>
+        </p>
+        <div id="loading">
+          <div style="height: 4vh;"></div>
+          <h4 style="text-align: center;">
+            Loading <span class="loader__dot">.</span><span class="loader__dot">.</span><span
+              class="loader__dot">.</span>
+          </h4>
+          <div style="height: 4vh;"></div>
+        </div>
+        <div id="math-problem">
+          <p>Solve the following system of equations for \(x\) and \(y.\)</p>
           <p>
-            <strong>Please solve the following simple math problem:</strong>
+            $$\left\{ \begin{array}{ll} \log x + \log y = \log 2\\ x^{2}+y^{2}
+            = 5 \end{array} \right.$$
           </p>
-          <div id="loading">
-            <div style="height: 4vh;"></div>
-            <h4 style="text-align: center;">
-              Loading <span class="loader__dot">.</span
-              ><span class="loader__dot">.</span
-              ><span class="loader__dot">.</span>
-            </h4>
-            <div style="height: 4vh;"></div>
-          </div>
-          <div id="math-problem">
-            <p>Solve the following system of equations for \(x\) and \(y.\)</p>
-            <p>
-              $$\left\{ \begin{array}{ll} \log x + \log y = \log 2\\ x^{2}+y^{2}
-              = 5 \end{array} \right.$$
-            </p>
-            <p>Enter your answers below:</p>
-            <form>
-              <div class="form-inline">
-                <div class="d-inline-block">
-                  <p style="display: inline-block;">\(x = \)</p>
-                  <input
-                    type="number"
-                    class="form-control"
-                    id="x-ans"
-                    placeholder="Enter your answer here"
-                  />
-                </div>
+          <p>Enter your answers below:</p>
+          <form>
+            <div class="form-inline">
+              <div class="d-inline-block">
+                <p style="display: inline-block;">\(x = \)</p>
+                <input type="number" class="form-control" id="x-ans" placeholder="Enter your answer here" />
               </div>
-              <div class="form-inline">
-                <div class="d-inline-block">
-                  <p style="display: inline-block;">\(y = \)</p>
-                  <input
-                    type="number"
-                    class="form-control"
-                    id="y-ans"
-                    placeholder="Enter your answer here"
-                  />
-                </div>
+            </div>
+            <div class="form-inline">
+              <div class="d-inline-block">
+                <p style="display: inline-block;">\(y = \)</p>
+                <input type="number" class="form-control" id="y-ans" placeholder="Enter your answer here" />
               </div>
-            </form>
-            <div style="height: 5vh;"></div>
-          </div>
-          <div id="new-problem">
-            <p>
-              A hypocycloid is the curve drawn by a point on a small circle
-              rolling inside a larger circle. The parametric equations of a
-              hypocycloid centered at the origin, and starting at the right most
-              point is given by:
-            </p>
-            <p>
-              $$x(t) = (R - r)\cos(t) + r\cos\left( \frac{R-r}{r}t \right)$$
-            </p>
-            <p>
-              $$y(t) = (R - r)\sin(t) - r\sin\left( \frac{R - r}{r}t \right)$$
-            </p>
-            <p>
-              Where \(R\) is the radius of the large circle and \(r\) the radius
-              of the small circle.
-            </p>
-            <p>
-              Let \(C(R, r)\) be the set of distinct points with integer
-              coordinates on the hypocycloid with radius \(R\) and \(r\) and for
-              which there is a corresponding value of \(t\) such that
-              \(\sin(t)\) and \(\cos(t)\) are rational numbers.
-            </p>
-            <p>
-              Let \(\sum_{(x, y)\in C(R, r)} |x|+|y|\) be the sum of the
-              absolute values of the \(x\) and \(y\) coordinates of the points
-              in \(C(R, r)\).
-            </p>
-            <p>
-              Let \(T(N) = \sum_{R=3}^{N}\sum_{r=1}^{\left
-              \lfloor{\frac{R-1}{2}}\right \rfloor } S(R, r)\) be the sum of
-              \(S(R, r)\) for \(R\) and \(r\) positive integers, \(R\leq N\) and
-              \(2r < R.\)
-            </p>
-            <p>You are given:</p>
-            <p>$$C(3, 1) = \{(3, 0), (-1, 2), (-1,0), (-1,-2)\}$$</p>
-            <p>
-              $$C(2500, 1000) = \{(2500, 0), (772, 2376), (772, -2376),$$
-            </p>
-            <p>
-              $$(516, 1792), (516, -1792), (500, 0), (68, 504),$$
-            </p>
-            <p>
-              $$(68, -504), (-1356, 1088), (-1356, -1088),$$
-            </p>
-            <p>$$(-1500, 1000), (-1500, -1000)\}$$</p>
-            <p>
-              <em>
-                Note: \((-625, 0)\) is not an element of \(C(2500, 1000)\)
-                because \(\sin(t)\) is not a rational number for the
-                corresponding values of \(t\).
-              </em>
-            </p>
-            <p>
-              $$S(3, 1) = (|3|+|0|) + (|-1| + |2|) + (|-1| + |0|) + $$
-            </p>
-            <p>$$(|-1| + |-2|) = 10$$</p>
-            <p>
-              $$T(3) = 10; T(10) = 524 ;T(100) = 580442;$$
-            </p>
-            <p>$$T\left(10^{3}\right) = 583108600.$$</p>
-            <p>Find \(T\left(10^{6}\right).\)</p>
-            <!-- div to create a bit more space -->
-            <div style="height: 3vh;"></div>
-            <form>
-              <div class="form-inline">
-                <div class="d-inline-block">
-                  <p style="display: inline-block;">
-                    \(T\left(10^{6}\right)\) =
-                  </p>
-                  <input
-                    type="number"
-                    class="form-control"
-                    id="hard-ans"
-                    placeholder="Enter your answer here"
-                  />
-                </div>
-              </div>
-            </form>
-            <div style="height: 4vh;"></div>
-            <p style="font-size: 10px; text-align: right;">
-              <em
-                >Problem still too difficult? Contact a representative to
-                manually login.</em
-              >
-            </p>
-          </div>
-          <p id="generate-problem">
-            <em
-              >Problem too difficult?
-              <a class="gen-new-problem" href="#gen-new">Click here</a>
-              to generate an easier problem.</em
-            >
+            </div>
+          </form>
+          <div style="height: 5vh;"></div>
+        </div>
+        <div id="new-problem">
+          <p>
+            A hypocycloid is the curve drawn by a point on a small circle
+            rolling inside a larger circle. The parametric equations of a
+            hypocycloid centered at the origin, and starting at the right most
+            point is given by:
           </p>
-          <div class="modal-footer">
-            <a href="connecting.html" class="btn btn-primary">
-              Submit
-            </a>
-          </div>
+          <p>
+            $$x(t) = (R - r)\cos(t) + r\cos\left( \frac{R-r}{r}t \right)$$
+          </p>
+          <p>
+            $$y(t) = (R - r)\sin(t) - r\sin\left( \frac{R - r}{r}t \right)$$
+          </p>
+          <p>
+            Where \(R\) is the radius of the large circle and \(r\) the radius
+            of the small circle.
+          </p>
+          <p>
+            Let \(C(R, r)\) be the set of distinct points with integer
+            coordinates on the hypocycloid with radius \(R\) and \(r\) and for
+            which there is a corresponding value of \(t\) such that
+            \(\sin(t)\) and \(\cos(t)\) are rational numbers.
+          </p>
+          <p>
+            Let \(\sum_{(x, y)\in C(R, r)} |x|+|y|\) be the sum of the
+            absolute values of the \(x\) and \(y\) coordinates of the points
+            in \(C(R, r)\).
+          </p>
+          <p>
+            Let \(T(N) = \sum_{R=3}^{N}\sum_{r=1}^{\left
+            \lfloor{\frac{R-1}{2}}\right \rfloor } S(R, r)\) be the sum of
+            \(S(R, r)\) for \(R\) and \(r\) positive integers, \(R\leq N\) and
+            \(2r < R.\) </p>
+              <p>You are given:</p>
+              <p>$$C(3, 1) = \{(3, 0), (-1, 2), (-1,0), (-1,-2)\}$$</p>
+              <p>
+                $$C(2500, 1000) = \{(2500, 0), (772, 2376), (772, -2376),$$
+              </p>
+              <p>
+                $$(516, 1792), (516, -1792), (500, 0), (68, 504),$$
+              </p>
+              <p>
+                $$(68, -504), (-1356, 1088), (-1356, -1088),$$
+              </p>
+              <p>$$(-1500, 1000), (-1500, -1000)\}$$</p>
+              <p>
+                <em>
+                  Note: \((-625, 0)\) is not an element of \(C(2500, 1000)\)
+                  because \(\sin(t)\) is not a rational number for the
+                  corresponding values of \(t\).
+                </em>
+              </p>
+              <p>
+                $$S(3, 1) = (|3|+|0|) + (|-1| + |2|) + (|-1| + |0|) + $$
+              </p>
+              <p>$$(|-1| + |-2|) = 10$$</p>
+              <p>
+                $$T(3) = 10; T(10) = 524 ;T(100) = 580442;$$
+              </p>
+              <p>$$T\left(10^{3}\right) = 583108600.$$</p>
+              <p>Find \(T\left(10^{6}\right).\)</p>
+              <!-- div to create a bit more space -->
+              <div style="height: 3vh;"></div>
+              <form>
+                <div class="form-inline">
+                  <div class="d-inline-block">
+                    <p style="display: inline-block;">
+                      \(T\left(10^{6}\right)\) =
+                    </p>
+                    <input type="number" class="form-control" id="hard-ans" placeholder="Enter your answer here" />
+                  </div>
+                </div>
+              </form>
+              <div style="height: 4vh;"></div>
+              <p style="font-size: 10px; text-align: right;">
+                <em>Problem still too difficult? Contact a representative to
+                  manually login.</em>
+              </p>
+        </div>
+        <p id="generate-problem">
+          <em>Problem too difficult?
+            <a class="gen-new-problem" href="#gen-new">Click here</a>
+            to generate an easier problem.</em>
+        </p>
+        <div class="modal-footer">
+          <a href="connecting" class="btn btn-primary">
+            Submit
+          </a>
         </div>
       </div>
     </div>
   </div>
-  <footer class="index">
-    <p>Deposit products offered by Felicity Bank Inc, N.A. Member FDIC.</p>
-    <p>Copyright &copy; 1969 - 2019 Felicity Bank Inc. All rights reserved. NMLSR ID 420024</p>
-  </footer>
+</div>
+<footer class="index">
+  <p>Deposit products offered by Felicity Bank Inc, N.A. Member FDIC.</p>
+  <p>Copyright &copy; 1969 - 2019 Felicity Bank Inc. All rights reserved. NMLSR ID 420024</p>
+</footer>
+
 </html>

--- a/invest.html
+++ b/invest.html
@@ -4,211 +4,192 @@
 <!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
 <!--[if gt IE 8]><!-->
 <html lang="en-US" class="no-js">
-  <!--<![endif]-->
-  <head>
-    <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <title>Invest | Felicity Bank Inc.</title>
-    <link
-      rel="shortcut icon"
-      type="image/png"
-      href="images/icon/dogecoin.png"
-    />
-    <link href="assets/font-awesome/css/font-awesome.min.css" rel="stylesheet" type="text/css">
-    <link rel="stylesheet" href="assets/css/style.css" />
-    <meta name="description" content="" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1, shrink-to-fit=no"
-    />
-    <!-- Bootstrap CSS -->
-    <link
-      rel="stylesheet"
-      href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
-      integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T"
-      crossorigin="anonymous"
-    />
-  </head>
-  <body>
-    <!--[if lt IE 7]>
+<!--<![endif]-->
+
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <title>Invest | Felicity Bank Inc.</title>
+  <link rel="shortcut icon" type="image/png" href="images/icon/dogecoin.png" />
+  <link href="assets/font-awesome/css/font-awesome.min.css" rel="stylesheet" type="text/css">
+  <link rel="stylesheet" href="assets/css/style.css" />
+  <meta name="description" content="" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+  <!-- Bootstrap CSS -->
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
+    integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous" />
+</head>
+
+<body>
+  <!--[if lt IE 7]>
       <p class="browsehappy">
         You are using an <strong>outdated</strong> browser. Please
         <a href="#">upgrade your browser</a> to improve your experience.
       </p>
     <![endif]-->
-    <nav
-      class="navbar navbar-expand-sm navbar-light bg-light border"
-      style="height: 8vh;"
-    >
-      <div class="container">
-        <a href="#" class="navbar-brand">Felicity Bank Inc.</a>
+  <nav class="navbar navbar-expand-sm navbar-light bg-light border" style="height: 8vh;">
+    <div class="container">
+      <a href="#" class="navbar-brand">Felicity Bank Inc.</a>
 
-        <button
-          class="navbar-toggler"
-          data-toggle="collapse"
-          data-target="#navbarMenu"
-        >
-          <span class="navbar-toggler-icon"></span>
-        </button>
+      <button class="navbar-toggler" data-toggle="collapse" data-target="#navbarMenu">
+        <span class="navbar-toggler-icon"></span>
+      </button>
 
-        <div class="collapse navbar-collapse" id="navbarMenu">
-          <ul class="navbar-nav ml-auto">
-            <li class="nav-link">
-              <a href="index.html">Home</a>
-            </li>
-            <li class="nav-link">
-              <a href="about.html">About Felicity Bank</a>
-            </li>
-            <li class="nav-link">
-              <a
-                href="https://en.wikipedia.org/wiki/Technical_support_scam"
-                target="_blank"
-                >Report Fraud</a
-              >
-            </li>
-            <li class="nav-link">
-              <a href="contact.html">Contact</a>
-            </li>
-          </ul>
+      <div class="collapse navbar-collapse" id="navbarMenu">
+        <ul class="navbar-nav ml-auto">
+          <li class="nav-link">
+            <a href="index">Home</a>
+          </li>
+          <li class="nav-link">
+            <a href="about">About Felicity Bank</a>
+          </li>
+          <li class="nav-link">
+            <a href="https://en.wikipedia.org/wiki/Technical_support_scam" target="_blank">Report Fraud</a>
+          </li>
+          <li class="nav-link">
+            <a href="contact">Contact</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+
+  <div style="height: 8vh;"></div>
+
+  <!-- in between the nav and login box -->
+
+  <div class="container">
+    <div class="page-header"></div>
+
+    <!-- Service List -->
+    <!-- The circle icons use Font Awesome's stacked icon classes. For more information, visit http://fontawesome.io/examples/ -->
+    <div class="row p-5 boxcol rounded ">
+      <div class="col-lg-12">
+        <h2 class="page-header">Where we invest your money</h2>
+        <hr>
+      </div>
+
+      <div class="col-md-4">
+        <div class="media">
+          <div class="pull-left">
+            <span class="fa-stack fa-2x">
+              <i class="fa fa-circle fa-stack-2x text-primary"></i>
+              <i class="fa fa-car fa-stack-1x fa-inverse"></i>
+            </span>
+          </div>
+          <div class="media-body">
+            <h4>Automotives</h4>
+            <p>Everyone has a car so it's a no brainer to invest here.</p>
+          </div>
+        </div>
+        <div class="media">
+          <div class="pull-left">
+            <span class="fa-stack fa-2x">
+              <i class="fa fa-circle fa-stack-2x text-primary"></i>
+              <i class="fa fa-facebook fa-stack-1x fa-inverse"></i>
+            </span>
+          </div>
+          <div class="media-body">
+            <h4>FaceBook</h4>
+            <p>We own basically all outstanding shares of FaceBook.</p>
+          </div>
+        </div>
+        <div class="media">
+          <div class="pull-left">
+            <span class="fa-stack fa-2x">
+              <i class="fa fa-circle fa-stack-2x text-primary"></i>
+              <i class="fa fa-bank fa-stack-1x fa-inverse"></i>
+            </span>
+          </div>
+          <div class="media-body">
+            <h4>Banking</h4>
+            <p>We like to gamble your money with our friends at other banks.</p>
+          </div>
         </div>
       </div>
-    </nav>
-
-    <div style="height: 8vh;"></div>
-
-    <!-- in between the nav and login box -->
-
-    <div class="container">
-      <div class="page-header"></div>
-
-      <!-- Service List -->
-      <!-- The circle icons use Font Awesome's stacked icon classes. For more information, visit http://fontawesome.io/examples/ -->
-      <div class="row p-5 boxcol rounded ">
-          <div class="col-lg-12">
-              <h2 class="page-header">Where we invest your money</h2>
-              <hr>
+      <div class="col-md-4">
+        <div class="media">
+          <div class="pull-left">
+            <span class="fa-stack fa-2x">
+              <i class="fa fa-circle fa-stack-2x text-primary"></i>
+              <i class="fa fa-wheelchair fa-stack-1x fa-inverse"></i>
+            </span>
           </div>
-
-          <div class="col-md-4">
-              <div class="media">
-                  <div class="pull-left">
-                      <span class="fa-stack fa-2x">
-                            <i class="fa fa-circle fa-stack-2x text-primary"></i>
-                            <i class="fa fa-car fa-stack-1x fa-inverse"></i>
-                      </span>
-                  </div>
-                  <div class="media-body">
-                      <h4>Automotives</h4>
-                      <p>Everyone has a car so it's a no brainer to invest here.</p>
-                  </div>
-              </div>
-              <div class="media">
-                  <div class="pull-left">
-                      <span class="fa-stack fa-2x">
-                            <i class="fa fa-circle fa-stack-2x text-primary"></i>
-                            <i class="fa fa-facebook fa-stack-1x fa-inverse"></i>
-                      </span>
-                  </div>
-                  <div class="media-body">
-                      <h4>FaceBook</h4>
-                      <p>We own basically all outstanding shares of FaceBook.</p>
-                  </div>
-              </div>
-              <div class="media">
-                  <div class="pull-left">
-                      <span class="fa-stack fa-2x">
-                            <i class="fa fa-circle fa-stack-2x text-primary"></i>
-                            <i class="fa fa-bank fa-stack-1x fa-inverse"></i>
-                      </span>
-                  </div>
-                  <div class="media-body">
-                      <h4>Banking</h4>
-                      <p>We like to gamble your money with our friends at other banks.</p>
-                  </div>
-              </div>
+          <div class="media-body">
+            <h4>Handicapped</h4>
+            <p>Handicapped, often referred to as technical support scammers.</p>
           </div>
-          <div class="col-md-4">
-              <div class="media">
-                  <div class="pull-left">
-                      <span class="fa-stack fa-2x">
-                            <i class="fa fa-circle fa-stack-2x text-primary"></i>
-                            <i class="fa fa-wheelchair fa-stack-1x fa-inverse"></i>
-                      </span>
-                  </div>
-                  <div class="media-body">
-                      <h4>Handicapped</h4>
-                      <p>Handicapped, often referred to as technical support scammers.</p>
-                  </div>
-              </div>
-              <div class="media">
-                  <div class="pull-left">
-                      <span class="fa-stack fa-2x">
-                            <i class="fa fa-circle fa-stack-2x text-primary"></i>
-                            <i class="fa fa-tree fa-stack-1x fa-inverse"></i>
-                      </span>
-                  </div>
-                  <div class="media-body">
-                      <h4>Environment</h4>
-                      <p>The environment keeps us alive, so invest in yourself.</p>
-                  </div>
-              </div>
-              <div class="media">
-                  <div class="pull-left">
-                      <span class="fa-stack fa-2x">
-                            <i class="fa fa-circle fa-stack-2x text-primary"></i>
-                            <i class="fa fa-apple fa-stack-1x fa-inverse"></i>
-                      </span>
-                  </div>
-                  <div class="media-body">
-                      <h4>Apple</h4>
-                      <p>We helped Steve Jobs fund Apple with your money.</p>
-                  </div>
-              </div>
+        </div>
+        <div class="media">
+          <div class="pull-left">
+            <span class="fa-stack fa-2x">
+              <i class="fa fa-circle fa-stack-2x text-primary"></i>
+              <i class="fa fa-tree fa-stack-1x fa-inverse"></i>
+            </span>
           </div>
-          <div class="col-md-4">
-              <div class="media">
-                  <div class="pull-left">
-                      <span class="fa-stack fa-2x">
-                            <i class="fa fa-circle fa-stack-2x text-primary"></i>
-                            <i class="fa fa-paper-plane fa-stack-1x fa-inverse"></i>
-                      </span>
-                  </div>
-                  <div class="media-body">
-                      <h4>Paper Planes</h4>
-                      <p>Paper planes are often an undervalued sector.</p>
-                  </div>
-              </div>
-              <div class="media">
-                  <div class="pull-left">
-                      <span class="fa-stack fa-2x">
-                            <i class="fa fa-circle fa-stack-2x text-primary"></i>
-                            <i class="fa fa-space-shuttle fa-stack-1x fa-inverse"></i>
-                      </span>
-                  </div>
-                  <div class="media-body">
-                      <h4>NASA</h4>
-                      <p>We funded the first ever trip to the moon in 1969.</p>
-                  </div>
-              </div>
-              <div class="media">
-                  <div class="pull-left">
-                      <span class="fa-stack fa-2x">
-                            <i class="fa fa-circle fa-stack-2x text-primary"></i>
-                            <i class="fa fa-bitcoin fa-stack-1x fa-inverse"></i>
-                      </span>
-                  </div>
-                  <div class="media-body">
-                      <h4>Bitcoin</h4>
-                      <p>How else are you going to get yourself a lamborghini?</p>
-                  </div>
-              </div>
+          <div class="media-body">
+            <h4>Environment</h4>
+            <p>The environment keeps us alive, so invest in yourself.</p>
           </div>
+        </div>
+        <div class="media">
+          <div class="pull-left">
+            <span class="fa-stack fa-2x">
+              <i class="fa fa-circle fa-stack-2x text-primary"></i>
+              <i class="fa fa-apple fa-stack-1x fa-inverse"></i>
+            </span>
+          </div>
+          <div class="media-body">
+            <h4>Apple</h4>
+            <p>We helped Steve Jobs fund Apple with your money.</p>
+          </div>
+        </div>
       </div>
-      <!-- /.row -->
+      <div class="col-md-4">
+        <div class="media">
+          <div class="pull-left">
+            <span class="fa-stack fa-2x">
+              <i class="fa fa-circle fa-stack-2x text-primary"></i>
+              <i class="fa fa-paper-plane fa-stack-1x fa-inverse"></i>
+            </span>
+          </div>
+          <div class="media-body">
+            <h4>Paper Planes</h4>
+            <p>Paper planes are often an undervalued sector.</p>
+          </div>
+        </div>
+        <div class="media">
+          <div class="pull-left">
+            <span class="fa-stack fa-2x">
+              <i class="fa fa-circle fa-stack-2x text-primary"></i>
+              <i class="fa fa-space-shuttle fa-stack-1x fa-inverse"></i>
+            </span>
+          </div>
+          <div class="media-body">
+            <h4>NASA</h4>
+            <p>We funded the first ever trip to the moon in 1969.</p>
+          </div>
+        </div>
+        <div class="media">
+          <div class="pull-left">
+            <span class="fa-stack fa-2x">
+              <i class="fa fa-circle fa-stack-2x text-primary"></i>
+              <i class="fa fa-bitcoin fa-stack-1x fa-inverse"></i>
+            </span>
+          </div>
+          <div class="media-body">
+            <h4>Bitcoin</h4>
+            <p>How else are you going to get yourself a lamborghini?</p>
+          </div>
+        </div>
       </div>
-      <br>
-    <footer>
-      <p>Deposit products offered by Felicity Bank Inc, N.A. Member FDIC.</p>
-      <p>Copyright &copy; 1969 - 2019 Felicity Bank Inc. All rights reserved. NMLSR ID 420024</p>
-    </footer>
+    </div>
+    <!-- /.row -->
+  </div>
+  <br>
+  <footer>
+    <p>Deposit products offered by Felicity Bank Inc, N.A. Member FDIC.</p>
+    <p>Copyright &copy; 1969 - 2019 Felicity Bank Inc. All rights reserved. NMLSR ID 420024</p>
+  </footer>
+
 </html>

--- a/logout.html
+++ b/logout.html
@@ -1,16 +1,20 @@
 ﻿<!doctype html>
- <html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <title>logging out...</title>
-        <meta http-equiv="refresh" content="8;URL=index.html">
-        <link rel="stylesheet" href="assets/css/connect.css">
-        <link href="https://fonts.googleapis.com/css?family=Lobster|Roboto:100&display=swap" rel="stylesheet">
-    </head>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <title>logging out...</title>
+    <meta http-equiv="refresh" content="8;URL=index">
+    <link rel="stylesheet" href="assets/css/connect.css">
+    <link href="https://fonts.googleapis.com/css?family=Lobster|Roboto:100&display=swap" rel="stylesheet">
+</head>
+
+<body>
+    <br />
+    <br />
+    <h1>Goodbye, we hope to see you again soon!</h1>
+    <img src="assets/images/loading.gif" />
+
     <body>
-        <br/>
-        <br/>
-        <h1>Goodbye, we hope to see you again soon!</h1>
-        <img src="assets/images/loading.gif"/>
-    <body>
+
 </html>

--- a/processing.html
+++ b/processing.html
@@ -1,16 +1,20 @@
 ﻿<!doctype html>
- <html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <title>processing...</title>
-        <meta http-equiv="refresh" content="10;URL=complete.html">
-        <link rel="stylesheet" href="assets/css/connect.css">
-        <link href="https://fonts.googleapis.com/css?family=Lobster|Roboto:100&display=swap" rel="stylesheet">
-    </head>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <title>processing...</title>
+    <meta http-equiv="refresh" content="10;URL=complete">
+    <link rel="stylesheet" href="assets/css/connect.css">
+    <link href="https://fonts.googleapis.com/css?family=Lobster|Roboto:100&display=swap" rel="stylesheet">
+</head>
+
+<body>
+    <br />
+    <br />
+    <h1>Securely processing your information via our secure servers, please wait a moment...</h1>
+    <img src="assets/images/loading.gif" />
+
     <body>
-        <br/>
-        <br/>
-        <h1>Securely processing your information via our secure servers, please wait a moment...</h1>
-        <img src="assets/images/loading.gif"/>
-    <body>
+
 </html>

--- a/sent.html
+++ b/sent.html
@@ -4,93 +4,71 @@
 <!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
 <!--[if gt IE 8]><!-->
 <html lang="en-US" class="no-js">
-  <!--<![endif]-->
-  <head>
-    <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <title>Sent | Felicity Bank Inc.</title>
-    <link
-      rel="shortcut icon"
-      type="image/png"
-      href="assets/images/icon/dogecoin.png"
-    />
-    <link rel="stylesheet" href="assets/css/style.css" />
-    <link href="assets/font-awesome/css/font-awesome.min.css" rel="stylesheet" type="text/css">
-    <meta name="description" content="" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1, shrink-to-fit=no"
-    />
-    <!-- Bootstrap CSS -->
-    <link
-      rel="stylesheet"
-      href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
-      integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T"
-      crossorigin="anonymous"
-    />
-  </head>
-  <body>
-    <!--[if lt IE 7]>
+<!--<![endif]-->
+
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <title>Sent | Felicity Bank Inc.</title>
+  <link rel="shortcut icon" type="image/png" href="assets/images/icon/dogecoin.png" />
+  <link rel="stylesheet" href="assets/css/style.css" />
+  <link href="assets/font-awesome/css/font-awesome.min.css" rel="stylesheet" type="text/css">
+  <meta name="description" content="" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+  <!-- Bootstrap CSS -->
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
+    integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous" />
+</head>
+
+<body>
+  <!--[if lt IE 7]>
       <p class="browsehappy">
         You are using an <strong>outdated</strong> browser. Please
         <a href="#">upgrade your browser</a> to improve your experience.
       </p>
     <![endif]-->
-    <nav
-      class="navbar navbar-expand-sm navbar-light bg-light border"
-      style="height: 8vh;"
-    >
-      <div class="container">
-        <a href="#" class="navbar-brand">Felicity Bank Inc.</a>
-
-        <button
-          class="navbar-toggler"
-          data-toggle="collapse"
-          data-target="#navbarMenu"
-        >
-          <span class="navbar-toggler-icon"></span>
-        </button>
-
-        <div class="collapse navbar-collapse" id="navbarMenu">
-          <ul class="navbar-nav ml-auto">
-            <li class="nav-link">
-              <a href="index.html">Home</a>
-            </li>
-            <li class="nav-link">
-              <a href="about.html">About Felicity Bank</a>
-            </li>
-            <li class="nav-link">
-              <a href="invest.html">Investing</a>
-            </li>
-            <li class="nav-link">
-              <a
-                href="https://en.wikipedia.org/wiki/Technical_support_scam"
-                target="_blank"
-                >Report Fraud</a
-              >
-            </li>
-            <li class="nav-link">
-              <a href="contact.html">Contact</a>
-            </li>
-          </ul>
-        </div>
-      </div>
-    </nav>
-
-    <div style="height: 8vh;"></div>
-
-    <!-- in between the nav and login box -->
-
+  <nav class="navbar navbar-expand-sm navbar-light bg-light border" style="height: 8vh;">
     <div class="container">
-      <div class="page-header"></div>
+      <a href="#" class="navbar-brand">Felicity Bank Inc.</a>
 
-      <center>
-      <div
-        class="shadow-sm p-3 mb-5 boxcol rounded col-lg-8 col-md-8 col-sm-8 col-xs-12"
-      >
+      <button class="navbar-toggler" data-toggle="collapse" data-target="#navbarMenu">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+
+      <div class="collapse navbar-collapse" id="navbarMenu">
+        <ul class="navbar-nav ml-auto">
+          <li class="nav-link">
+            <a href="index">Home</a>
+          </li>
+          <li class="nav-link">
+            <a href="about">About Felicity Bank</a>
+          </li>
+          <li class="nav-link">
+            <a href="invest">Investing</a>
+          </li>
+          <li class="nav-link">
+            <a href="https://en.wikipedia.org/wiki/Technical_support_scam" target="_blank">Report Fraud</a>
+          </li>
+          <li class="nav-link">
+            <a href="contact">Contact</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+
+  <div style="height: 8vh;"></div>
+
+  <!-- in between the nav and login box -->
+
+  <div class="container">
+    <div class="page-header"></div>
+
+    <center>
+      <div class="shadow-sm p-3 mb-5 boxcol rounded col-lg-8 col-md-8 col-sm-8 col-xs-12">
         <span class="fa-stack fa-2x">
-            <font color="green"><i class="fa fa-circle fa-stack-2x"></i></font>
-            <i class="fa fa-check fa-stack-1x fa-inverse"></i>
+          <font color="green"><i class="fa fa-circle fa-stack-2x"></i></font>
+          <i class="fa fa-check fa-stack-1x fa-inverse"></i>
         </span>
         <h2>Email Sent</h2>
 
@@ -98,17 +76,19 @@
         <br>
 
         <p style="font-size: 18px;">
-          If you have an account registered here with the email you submitted, you will have an email in your inbox with your account information.
+          If you have an account registered here with the email you submitted, you will have an email in your inbox with
+          your account information.
         </p>
 
         <hr />
         <br>
 
       </div>
-      </center>
-    </div>
+    </center>
+  </div>
   <footer>
     <p>Deposit products offered by Felicity Bank Inc, N.A. Member FDIC.</p>
     <p>Copyright &copy; 1969 - 2019 Felicity Bank Inc. All rights reserved. NMLSR ID 420024</p>
   </footer>
+
 </html>


### PR DESCRIPTION
> Closes #3 

I've added a .htaccess file which rewrites any request without an extension to *.html. This only works for HTML files, so assets still work the same.

I also refactored the project to change all URL links to the new system. So, the extensions should now be completely hidden.

For example, this is what the account URL now looks like:

![Account URL](https://i.imgur.com/btMMo0X.png)

_While I was refactoring, the editor reformatted all your HTML, sorry about that._